### PR TITLE
fix: use absolute paths in hook scripts for cross-project compatibility

### DIFF
--- a/.claude/hooks/consolidate.sh
+++ b/.claude/hooks/consolidate.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Session end: consolidate accumulated memories (dedup, prune, detect contradictions).
-cd "$(dirname "$0")/../.."
-tsx scripts/run.ts consolidate >/dev/null 2>&1 &
+SNOO="$(cd "$(dirname "$0")/../.." && pwd)"
+TSX="$SNOO/node_modules/.bin/tsx"
+
+cd "$SNOO"
+"$TSX" "$SNOO/scripts/run.ts" consolidate >/dev/null 2>&1 &
 disown
 exit 0

--- a/.claude/hooks/record-tool.sh
+++ b/.claude/hooks/record-tool.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Post-task: record Edit/Write/Agent outcomes for learning.
 # Matched by PostToolUse and PostToolUseFailure for non-Bash tools.
+SNOO="$(cd "$(dirname "$0")/../.." && pwd)"
+TSX="$SNOO/node_modules/.bin/tsx"
+
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
 [ -z "$TOOL" ] && exit 0
@@ -32,7 +35,7 @@ esac
 
 # Truncate and record in background (don't block Claude)
 DESC="${DESC:0:500}"
-cd "$(dirname "$0")/../.."
-tsx scripts/run.ts post "$DESC" "$EXIT_CODE" >/dev/null 2>&1 &
+cd "$SNOO"
+"$TSX" "$SNOO/scripts/run.ts" post "$DESC" "$EXIT_CODE" >/dev/null 2>&1 &
 disown
 exit 0

--- a/.claude/hooks/record.sh
+++ b/.claude/hooks/record.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Post-task: record meaningful command outcomes for learning.
 # Shared by PostToolUse[Bash] and PostToolUseFailure[Bash].
+SNOO="$(cd "$(dirname "$0")/../.." && pwd)"
+TSX="$SNOO/node_modules/.bin/tsx"
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 [ -z "$COMMAND" ] && exit 0
@@ -21,7 +24,7 @@ EVENT=$(echo "$INPUT" | jq -r '.hook_event_name // "PostToolUse"')
 
 # Truncate and record in background (don't block Claude)
 COMMAND="${COMMAND:0:500}"
-cd "$(dirname "$0")/../.."
-tsx scripts/run.ts post "$COMMAND" "$EXIT_CODE" >/dev/null 2>&1 &
+cd "$SNOO"
+"$TSX" "$SNOO/scripts/run.ts" post "$COMMAND" "$EXIT_CODE" >/dev/null 2>&1 &
 disown
 exit 0

--- a/.claude/hooks/retrieve.sh
+++ b/.claude/hooks/retrieve.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 # Pre-task: retrieve learned patterns relevant to the user's prompt.
 # Stdout is injected into Claude's context via UserPromptSubmit hook.
+SNOO="$(cd "$(dirname "$0")/../.." && pwd)"
+TSX="$SNOO/node_modules/.bin/tsx"
+
 INPUT=$(cat)
 PROMPT=$(echo "$INPUT" | jq -r '.user_prompt // empty')
 [ -z "$PROMPT" ] && exit 0
 
-cd "$(dirname "$0")/../.."
+cd "$SNOO"
 
 # ADR-001: Auto-start persistent embed server if not running
 SOCK=".swarm/embed.sock"
@@ -20,16 +23,14 @@ if ! server_alive; then
   # Clean up stale socket/pid from crashed server
   rm -f "$SOCK" "$PID_FILE"
   # Start server fully detached: nohup + setsid + /dev/null stdin
-  # (nohup ignores SIGHUP, setsid creates new session, /dev/null detaches stdin)
-  nohup setsid tsx scripts/embed-server.ts </dev/null >> .swarm/embed-server.log 2>&1 &
+  nohup setsid "$TSX" "$SNOO/scripts/embed-server.ts" </dev/null >> .swarm/embed-server.log 2>&1 &
   # Poll for readiness (socket appears after model load, ~400ms)
   for i in $(seq 1 20); do  # 20 x 100ms = 2s max wait
     [ -S "$SOCK" ] && break
     sleep 0.1
   done
-  # If still no socket after 2s, proceed — embeddings.ts falls back to in-process
 fi
 
 PROMPT="${PROMPT:0:500}"
-tsx scripts/run.ts pre "$PROMPT" 2>/dev/null || true
+"$TSX" "$SNOO/scripts/run.ts" pre "$PROMPT" 2>/dev/null || true
 exit 0


### PR DESCRIPTION
## Summary

- Hook scripts called `tsx` directly, but it's not in PATH — only available as a local binary in `node_modules/.bin/tsx`
- Relative `scripts/run.ts` paths resolve against the caller's CWD (the external project) rather than snoo-flow's directory when backgrounded with `&`
- Both failures are silent because output is redirected to `/dev/null`, so users never know hooks aren't working

Fix: resolve `SNOO` dir once at script start, use `node_modules/.bin/tsx` and absolute script paths throughout.

## Test plan

- [x] Verified hooks work when called from an external project directory
- [x] Verified hooks still work when called from within snoo-flow
- [x] All 31 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)