### PR TITLE
feat: add retrieval logging for performance observability

### DIFF
--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -74,6 +74,23 @@ async function main() {
     output(`Patterns: ${patterns.length}`);
     output(`Trajectories: ${trajCount}`);
 
+  } else if (cmd === 'log') {
+    const limit = parseInt(rest[0], 10) || 20;
+    const entries = db.getRetrievalLog(limit);
+    if (entries.length === 0) {
+      output('No retrieval log entries yet.');
+    } else {
+      for (const e of entries) {
+        const results = JSON.parse(e.results_json);
+        output(`[${e.created_at}] ${e.duration_ms}ms | ${e.memories_returned}/${e.memories_considered} memories`);
+        output(`  Prompt: ${e.prompt.substring(0, 80)}${e.prompt.length > 80 ? '...' : ''}`);
+        for (const r of results) {
+          output(`    - "${r.title}" score=${r.score.toFixed(3)} sim=${r.similarity.toFixed(3)}`);
+        }
+        output('');
+      }
+    }
+
   } else if (cmd === 'consolidate') {
     const result = await consolidate();
     output(`Consolidation complete: ${result.duplicatesFound} dupes, ${result.contradictionsFound} contradictions, ${result.itemsPruned} pruned (${result.itemsProcessed} processed in ${result.durationMs}ms)`);
@@ -85,6 +102,7 @@ async function main() {
 Commands:
   pre  "task description"              Retrieve prior patterns before starting work
   post "task description" [exit-code]  Record what happened (0=success, 1=failure)
+  log  [limit]                         Show recent retrieval log (default: 20)
   consolidate                          Run memory consolidation (dedup, prune)
   stats                                Show memory stats`);
   }

--- a/src/reasoningbank/core/retrieve.ts
+++ b/src/reasoningbank/core/retrieve.ts
@@ -93,7 +93,7 @@ export async function retrieveMemories(
   console.log(`[INFO] Retrieval complete: ${selected.length} memories in ${duration}ms`);
   db.logMetric('rb.retrieve.latency_ms', duration);
 
-  return selected.map((item: any) => ({
+  const results = selected.map((item: any) => ({
     id: item.id,
     title: item.pattern_data.title,
     description: item.pattern_data.description,
@@ -101,6 +101,22 @@ export async function retrieveMemories(
     score: item.score,
     components: item.components
   }));
+
+  // 6. Log retrieval for observability
+  db.logRetrieval({
+    prompt: query,
+    memoriesReturned: results.length,
+    memoriesConsidered: candidates.length,
+    results: results.map(r => ({
+      id: r.id,
+      title: r.title,
+      score: r.score,
+      similarity: r.components.similarity,
+    })),
+    durationMs: duration,
+  });
+
+  return results;
 }
 
 /**

--- a/src/reasoningbank/db/queries.ts
+++ b/src/reasoningbank/db/queries.ts
@@ -108,6 +108,19 @@ export async function runMigrations(): Promise<void> {
       timestamp TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     );
 
+    CREATE TABLE IF NOT EXISTS retrieval_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      prompt TEXT NOT NULL,
+      memories_returned INTEGER NOT NULL,
+      memories_considered INTEGER NOT NULL,
+      top_score REAL,
+      top_similarity REAL,
+      results_json TEXT NOT NULL,
+      duration_ms INTEGER NOT NULL,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_retrieval_log_created ON retrieval_log(created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_patterns_type ON patterns(type);
     CREATE INDEX IF NOT EXISTS idx_patterns_confidence ON patterns(confidence DESC);
     CREATE INDEX IF NOT EXISTS idx_patterns_created_at ON patterns(created_at DESC);
@@ -447,6 +460,59 @@ export function pruneOldMemories(options: {
   `).run(options.minConfidence, options.maxAgeDays);
 
   return result.changes;
+}
+
+/**
+ * Log a retrieval event for observability
+ */
+export function logRetrieval(entry: {
+  prompt: string;
+  memoriesReturned: number;
+  memoriesConsidered: number;
+  results: Array<{ id: string; title: string; score: number; similarity: number }>;
+  durationMs: number;
+}): void {
+  try {
+    const db = getDb();
+    db.prepare(`
+      INSERT INTO retrieval_log
+        (prompt, memories_returned, memories_considered, top_score, top_similarity, results_json, duration_ms)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      entry.prompt.substring(0, 500),
+      entry.memoriesReturned,
+      entry.memoriesConsidered,
+      entry.results[0]?.score ?? null,
+      entry.results[0]?.similarity ?? null,
+      JSON.stringify(entry.results),
+      entry.durationMs
+    );
+  } catch {
+    // Non-critical — don't break retrieval if logging fails
+  }
+}
+
+/**
+ * Fetch recent retrieval log entries
+ */
+export function getRetrievalLog(limit = 20): Array<{
+  prompt: string;
+  memories_returned: number;
+  memories_considered: number;
+  top_score: number | null;
+  top_similarity: number | null;
+  results_json: string;
+  duration_ms: number;
+  created_at: string;
+}> {
+  const db = getDb();
+  return db.prepare(`
+    SELECT prompt, memories_returned, memories_considered,
+           top_score, top_similarity, results_json, duration_ms, created_at
+    FROM retrieval_log
+    ORDER BY created_at DESC
+    LIMIT ?
+  `).all(limit) as any[];
 }
 
 /**

--- a/tests/phase4-e2e.test.js
+++ b/tests/phase4-e2e.test.js
@@ -152,6 +152,33 @@ describe('Phase 4: End-to-End Learning Loop', () => {
     testDb.close();
   });
 
+  it('retrieval_log captures retrieval events', async () => {
+    const testDb = new Database(testDbPath, { readonly: true });
+
+    const rows = testDb.prepare(
+      `SELECT * FROM retrieval_log ORDER BY created_at DESC`
+    ).all();
+
+    assert.ok(rows.length > 0, `retrieval_log should have entries, got ${rows.length}`);
+
+    const entry = rows[0];
+    assert.ok(entry.prompt.length > 0, 'prompt should not be empty');
+    assert.ok(entry.memories_returned > 0, 'should have returned memories');
+    assert.ok(entry.memories_considered > 0, 'should have considered candidates');
+    assert.ok(entry.duration_ms >= 0, 'duration should be non-negative');
+    assert.ok(entry.top_score > 0, 'top_score should be positive');
+    assert.ok(entry.top_similarity > 0, 'top_similarity should be positive');
+
+    const results = JSON.parse(entry.results_json);
+    assert.ok(Array.isArray(results), 'results_json should parse to array');
+    assert.ok(results[0].id, 'result should have id');
+    assert.ok(results[0].title, 'result should have title');
+    assert.ok(typeof results[0].score === 'number', 'result should have numeric score');
+    assert.ok(typeof results[0].similarity === 'number', 'result should have numeric similarity');
+
+    testDb.close();
+  });
+
   it('all patterns have embeddings', async () => {
     const testDb = new Database(testDbPath, { readonly: true });
 


### PR DESCRIPTION
## Summary

Adds a `retrieval_log` SQLite table that records every memory retrieval event, enabling users to audit what memories are being served and tune thresholds.

Closes #3

## What changed

| File | Change |
|------|--------|
| `src/reasoningbank/db/queries.ts` | New `retrieval_log` table in migrations, `logRetrieval()` and `getRetrievalLog()` functions |
| `src/reasoningbank/core/retrieve.ts` | Calls `logRetrieval()` after each retrieval with prompt, scores, and results |
| `scripts/run.ts` | New `log [limit]` CLI command to inspect recent retrievals |
| `tests/phase4-e2e.test.js` | New test validating retrieval log entries are created with correct structure |

## What gets logged

Each retrieval records:
- **Prompt** (truncated to 500 chars)
- **Memories returned** vs **considered** (e.g. 3/47)
- **Top score** and **top similarity**
- **Per-result details** (id, title, score, similarity) as JSON
- **Duration** in ms
- **Timestamp**

## Usage

```bash
# View last 20 retrievals
npm run snoo log

# View last 5
npm run snoo log 5
```

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 32/32 pass (new test included)